### PR TITLE
[Feature] 진행 카드 조회 기능 구현

### DIFF
--- a/src/main/java/com/pm/projectmanager/common/response/ResponseCodeEnum.java
+++ b/src/main/java/com/pm/projectmanager/common/response/ResponseCodeEnum.java
@@ -43,7 +43,8 @@ public enum ResponseCodeEnum {
     CARD_DELETE_SUCCESS(HttpStatus.OK, "카드 삭제 성공"),
     CARD_SELECT_DETAIL_SUCCESS(HttpStatus.OK, "카드 상세 조회 성공"),
     CARD_COMPLETE_SUCCESS(HttpStatus.OK, "카드 완료 상태 변경 성공"),
-    CARD_PROGRESS_SUCCESS(HttpStatus.OK, "카드 진행 상태 변경 성공");
+    CARD_PROGRESS_SUCCESS(HttpStatus.OK, "카드 진행 상태 변경 성공"),
+    CARD_PROGRESS_SELECT_SUCCESS(HttpStatus.OK, "내 진행 카드 조회 성공");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/pm/projectmanager/domain/card/CardController.java
+++ b/src/main/java/com/pm/projectmanager/domain/card/CardController.java
@@ -1,11 +1,13 @@
 package com.pm.projectmanager.domain.card;
 
+import com.pm.projectmanager.common.PageableResponse;
 import com.pm.projectmanager.common.response.HttpResponseDto;
 import com.pm.projectmanager.domain.card.dto.CompleteCardRequestDto;
 import com.pm.projectmanager.domain.card.dto.DeleteCardRequestDto;
 import com.pm.projectmanager.domain.card.dto.UpdateCardRequestDto;
 import com.pm.projectmanager.security.UserDetailsImpl;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -66,6 +68,17 @@ public class CardController {
     {
         cardService.progressCard(cardId, userDetails.getUser());
         return of(CARD_PROGRESS_SUCCESS);
+    }
+
+    // 개인의 진행 중인 카드 조회
+    @GetMapping("/progress")
+    public ResponseEntity<HttpResponseDto> selectProgressCard(
+            @RequestParam(value = "page", defaultValue = "0") int page,
+            @RequestParam(value = "size", defaultValue = "5") int size,
+            @AuthenticationPrincipal UserDetailsImpl userDetails)
+    {
+        Page<Card> cards = cardService.selectProgressCard(userDetails.getUser(), page, size);
+        return of(CARD_PROGRESS_SELECT_SUCCESS, new PageableResponse<>(cards));
     }
 
 }

--- a/src/main/java/com/pm/projectmanager/domain/card/CardRepository.java
+++ b/src/main/java/com/pm/projectmanager/domain/card/CardRepository.java
@@ -1,5 +1,7 @@
 package com.pm.projectmanager.domain.card;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -11,4 +13,5 @@ public interface CardRepository extends JpaRepository<Card, Long> {
     List<Card> findAllByCompleteDateIsNull();
     List<Card> findAllBySectionId(Long sectionId);
     Optional<Card> findByIdAndUserId(Long cardId, Long userId);
+    Page<Card> findByUserIdAndCompleteDateIsNull(Long userId, Pageable pageable);
 }

--- a/src/main/java/com/pm/projectmanager/domain/card/CardService.java
+++ b/src/main/java/com/pm/projectmanager/domain/card/CardService.java
@@ -12,6 +12,9 @@ import com.pm.projectmanager.domain.section.SectionRepository;
 import com.pm.projectmanager.domain.user.User;
 import com.pm.projectmanager.exception.*;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -111,6 +114,11 @@ public class CardService {
         card.progress();
     }
 
+    public Page<Card> selectProgressCard(User user, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size);
+        return cardRepository.findByUserIdAndCompleteDateIsNull(user.getId(), pageable);
+    }
+
     // 프로젝트에 유저가 속해있는지 여부 검증
     private void validateUserInProject(Long projectId, Long userId) {
         hasProject(projectId);
@@ -133,4 +141,5 @@ public class CardService {
             throw new SectionException(ResponseExceptionEnum.SECTION_NOT_FOUND);
         }
     }
+
 }


### PR DESCRIPTION
## 🏠 제목
> [Feature] 진행 카드 조회 기능 구현

## #️⃣ 관련 이슈
> Closes #27 

## 📑 작업 내용
> - 페이징 처리를 위해 브라우저에서 page의 값을 받고 진행하며, size는 디폴트 값으로 5를 지정 페이징 처리 후 리턴

## ✅ 참고 사항
> - 없음
