### PR TITLE
Refactor: 닉네임 미수정시 유저수정 안되는 현상 해결

### DIFF
--- a/src/main/java/com/pm/projectmanager/domain/user/UserService.java
+++ b/src/main/java/com/pm/projectmanager/domain/user/UserService.java
@@ -53,7 +53,7 @@ public class UserService {
 	@Transactional
 	public void update(UpdateRequestDto requestDto, UserDetailsImpl userDetails) {
 
-		if (userRepository.existsByNickname(requestDto.getNickname())) {
+		if (!requestDto.getNickname().equals(userDetails.getUser().getNickname()) && userRepository.existsByNickname(requestDto.getNickname())) {
 			throw new UserAlreadyExistsException(ResponseExceptionEnum.NICKNAME_ALREADY_EXISTS);
 		}
 


### PR DESCRIPTION
## 🏠 제목
> 닉네임 미수정시 유저수정 안되는 현상 해결

## #️⃣ 관련 이슈
> #4 

## 📑 작업 내용
> - 닉네임 수정하지 않고 유저 수정 시, 중복된 닉네임이라고 뜨는 현상 해결

## ✅ 참고 사항
> 
