### PR TITLE
초대 관련 api 수정 및 추가

### DIFF
--- a/src/main/java/com/pm/projectmanager/common/RedisService.java
+++ b/src/main/java/com/pm/projectmanager/common/RedisService.java
@@ -1,5 +1,6 @@
 package com.pm.projectmanager.common;
 
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
 import org.springframework.data.redis.core.RedisTemplate;
@@ -15,7 +16,6 @@ public class RedisService {
 
 	private final RedisTemplate<String, String> redisTemplate;
 	private final Long refreshTokenExpiration = 14 * 24 * 60 * 60 * 1000L; // 14일
-	private final Long inviteExpiration = 3 * 24 * 60 * 60 * 1000L; // 3일
 
 	@Transactional
 	public void saveRefreshToken(String email, String refreshToken) {
@@ -27,12 +27,15 @@ public class RedisService {
 	}
 
 	public void invite(String email, Long projectId) {
-		String stringProjectId = String.valueOf(projectId);
-		redisTemplate.opsForSet().add(inviteKey(email), stringProjectId);
+		redisTemplate.opsForSet().add(inviteKey(email), String.valueOf(projectId));
 	}
 
 	public boolean checkInvite(String email, Long projectId) {
 		return redisTemplate.opsForSet().isMember(inviteKey(email), String.valueOf(projectId));
+	}
+
+	public Set<String> getInvites(String email) {
+		return redisTemplate.opsForSet().members(inviteKey(email));
 	}
 
 	private String inviteKey(String email) {

--- a/src/main/java/com/pm/projectmanager/common/RedisService.java
+++ b/src/main/java/com/pm/projectmanager/common/RedisService.java
@@ -27,15 +27,16 @@ public class RedisService {
 	}
 
 	public void invite(String email, Long projectId) {
-		redisTemplate.opsForValue().set(inviteKey(email, projectId), "pending", inviteExpiration, TimeUnit.MILLISECONDS);
+		String stringProjectId = String.valueOf(projectId);
+		redisTemplate.opsForSet().add(inviteKey(email), stringProjectId);
 	}
 
 	public boolean checkInvite(String email, Long projectId) {
-		return redisTemplate.hasKey("invite:" + email + ":" + projectId);
+		return redisTemplate.opsForSet().isMember(inviteKey(email), String.valueOf(projectId));
 	}
 
-	private String inviteKey(String email, Long projectId) {
-		return "invite:" + email + ":" + projectId;
+	private String inviteKey(String email) {
+		return "invite:" + email;
 	}
 
 	public void deleteRefreshToken(String email) {
@@ -43,6 +44,6 @@ public class RedisService {
 	}
 
 	public void deleteInvite(String email, Long projectId) {
-		redisTemplate.delete(inviteKey(email, projectId));
+		redisTemplate.opsForSet().remove((inviteKey(email)), String.valueOf(projectId));
 	}
 }

--- a/src/main/java/com/pm/projectmanager/common/response/ResponseCodeEnum.java
+++ b/src/main/java/com/pm/projectmanager/common/response/ResponseCodeEnum.java
@@ -26,6 +26,7 @@ public enum ResponseCodeEnum {
 	PROJECT_REFUSE_SUCCESS(HttpStatus.OK, "프로젝트 초대 거절 성공"),
 	PROJECT_USER_GET_SUCCESS(HttpStatus.OK, "프로젝트 유저 조회 성공"),
 	PROJECT_USER_DELETE_SUCCESS(HttpStatus.OK, "프로젝트 유저 제거 성공"),
+	PROJECT_INVITE_GET_SUCCESS(HttpStatus.OK, "프로젝트 초대 조회 성공"),
     // category
     CATEGORY_CREATE_SUCCESS(HttpStatus.OK, "카테고리 생성 성공"),
     CATEGORY_SELECT_SUCCESS(HttpStatus.OK, "카테고리 조회 성공"),

--- a/src/main/java/com/pm/projectmanager/common/response/ResponseExceptionEnum.java
+++ b/src/main/java/com/pm/projectmanager/common/response/ResponseExceptionEnum.java
@@ -16,6 +16,7 @@ public enum ResponseExceptionEnum {
 	PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
 	AUTHORITY_NULL_EXCEPTION(HttpStatus.FORBIDDEN, "해당 프로젝트에 권한이 없습니다."),
 	NO_INVITE_EXCEPTION(HttpStatus.NOT_FOUND, "해당 프로젝트에서 받은 초대가 없습니다."),
+	AUTHORITY_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 초대된 유저입니다."),
     // category
     CATEGORY_NAME_ALREADY_EXISTS_IN_PROJECT(HttpStatus.BAD_REQUEST, "프로젝트 내에서 카테고리명이 이미 존재합니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),

--- a/src/main/java/com/pm/projectmanager/domain/authority/AuthorityRepository.java
+++ b/src/main/java/com/pm/projectmanager/domain/authority/AuthorityRepository.java
@@ -17,4 +17,5 @@ public interface AuthorityRepository extends JpaRepository<Authority, Long> {
 	void deleteByUserId(Long id);
 
 	List<Authority> findByProjectId(Long projectId);
+
 }

--- a/src/main/java/com/pm/projectmanager/domain/project/ProjectController.java
+++ b/src/main/java/com/pm/projectmanager/domain/project/ProjectController.java
@@ -4,6 +4,7 @@ import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_ACC
 import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_CREATE_SUCCESS;
 import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_DELETE_SUCCESS;
 import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_GET_SUCCESS;
+import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_INVITE_GET_SUCCESS;
 import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_INVITE_SUCCESS;
 import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_REFUSE_SUCCESS;
 import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_UPDATE_SUCCESS;
@@ -12,6 +13,7 @@ import static com.pm.projectmanager.common.response.ResponseCodeEnum.PROJECT_USE
 import static com.pm.projectmanager.common.response.ResponseUtils.of;
 
 import java.util.List;
+import java.util.Set;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -95,6 +97,14 @@ public class ProjectController {
 	) {
 		projectService.invite(requestDto, userDetails, projectId);
 		return of(PROJECT_INVITE_SUCCESS);
+	}
+
+	@GetMapping("/invite")
+	public ResponseEntity<HttpResponseDto> getInvite(
+		@AuthenticationPrincipal UserDetailsImpl userDetails
+	) {
+		Set<String> projectIds = projectService.getInvite(userDetails);
+		return of(PROJECT_INVITE_GET_SUCCESS, projectIds);
 	}
 
 	@DeleteMapping("/{projectId}/{userId}")

--- a/src/main/java/com/pm/projectmanager/domain/project/ProjectController.java
+++ b/src/main/java/com/pm/projectmanager/domain/project/ProjectController.java
@@ -89,7 +89,7 @@ public class ProjectController {
 		return of(PROJECT_DELETE_SUCCESS);
 	}
 
-	@PostMapping("/invite/{projectId}")
+	@PostMapping("/invites/{projectId}")
 	public ResponseEntity<HttpResponseDto> invite(
 		@RequestBody ProjectInviteDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
@@ -99,7 +99,7 @@ public class ProjectController {
 		return of(PROJECT_INVITE_SUCCESS);
 	}
 
-	@GetMapping("/invite")
+	@GetMapping("/invites")
 	public ResponseEntity<HttpResponseDto> getInvite(
 		@AuthenticationPrincipal UserDetailsImpl userDetails
 	) {

--- a/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
+++ b/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
@@ -132,7 +132,6 @@ public class ProjectService {
 
 	@Transactional
 	public void inviteAccept(Long projectId, UserDetailsImpl userDetails) {
-		authorityCheck(projectId, userDetails);
 
 		if (redisService.checkInvite(userDetails.getUser().getEmail(), projectId)) {
 			Project project = projectRepository.findById(projectId)

--- a/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
+++ b/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
@@ -1,6 +1,7 @@
 package com.pm.projectmanager.domain.project;
 
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.pm.projectmanager.common.Color;
@@ -129,6 +130,9 @@ public class ProjectService {
 		}
 	}
 
+	public Set<String> getInvite(UserDetailsImpl userDetails) {
+		return redisService.getInvites(userDetails.getUsername());
+	}
 
 	@Transactional
 	public void inviteAccept(Long projectId, UserDetailsImpl userDetails) {
@@ -180,7 +184,6 @@ public class ProjectService {
 			throw new AuthorityNullException(ResponseExceptionEnum.AUTHORITY_NULL_EXCEPTION);
 		}
 	}
-
 
 }
 

--- a/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
+++ b/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
@@ -22,6 +22,7 @@ import com.pm.projectmanager.domain.project.dto.ProjectResponseDto;
 import com.pm.projectmanager.domain.project.dto.ProjectUpdateDto;
 import com.pm.projectmanager.domain.section.SectionRepository;
 import com.pm.projectmanager.domain.user.dto.UserResponseDto;
+import com.pm.projectmanager.exception.AuthorityAlreadyExistsException;
 import com.pm.projectmanager.exception.AuthorityNullException;
 import com.pm.projectmanager.exception.NoInviteException;
 import com.pm.projectmanager.exception.ProjectNullException;
@@ -125,8 +126,13 @@ public class ProjectService {
 
 		List<String> emailList = requestDto.getEmails();
 
+
 		for (String email : emailList) {
-			inviteCreate(projectId, email);
+			if (!hasAuthority(projectId, email)) {
+				inviteCreate(projectId, email);
+			} else {
+				throw new AuthorityAlreadyExistsException(ResponseExceptionEnum.AUTHORITY_ALREADY_EXISTS);
+			}
 		}
 	}
 
@@ -184,6 +190,13 @@ public class ProjectService {
 			throw new AuthorityNullException(ResponseExceptionEnum.AUTHORITY_NULL_EXCEPTION);
 		}
 	}
+
+	public boolean hasAuthority(Long projectId, String username) {
+		List<Authority> authorities = authorityRepository.findByProjectId(projectId);
+
+		return authorities.stream().anyMatch(auth -> auth.getUser().getEmail().equals(username));
+	}
+
 
 }
 

--- a/src/main/java/com/pm/projectmanager/exception/AuthorityAlreadyExistsException.java
+++ b/src/main/java/com/pm/projectmanager/exception/AuthorityAlreadyExistsException.java
@@ -1,0 +1,9 @@
+package com.pm.projectmanager.exception;
+
+import com.pm.projectmanager.common.response.ResponseExceptionEnum;
+
+public class AuthorityAlreadyExistsException extends CommonException {
+	public AuthorityAlreadyExistsException(ResponseExceptionEnum responseCodeEnum) {
+		super(responseCodeEnum);
+	}
+}


### PR DESCRIPTION
## 🏠 제목
> 초대 관련 api 수정 및 추가

## #️⃣ 관련 이슈
> #6 

## 📑 작업 내용
> - 프로젝트 초대 방식 일부 수정
      - redis에 단일 키 저장 대신, Set을 활용하여 한 key 안에 여러 value를 저장
> - 초대된 프로젝트 구현
      - 해당 유저의 초대된 프로젝트들을 가져오는 api 구현
> - 이미 초대된 유저 초대 방지
> - api 일부 수정
      - invite -> invites

## ✅ 참고 사항
>
