### PR TITLE
[Feature] 댓글 알림 기능 구현

### DIFF
--- a/src/main/java/com/pm/projectmanager/common/RedisService.java
+++ b/src/main/java/com/pm/projectmanager/common/RedisService.java
@@ -1,8 +1,12 @@
 package com.pm.projectmanager.common;
 
+import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import com.pm.projectmanager.common.response.ResponseExceptionEnum;
+import com.pm.projectmanager.exception.NotificationNotFoundException;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -49,4 +53,22 @@ public class RedisService {
 	public void deleteInvite(String email, Long projectId) {
 		redisTemplate.opsForSet().remove((inviteKey(email)), String.valueOf(projectId));
 	}
+
+    public void commentNotifications(Long cardMasterUser, String cardMasterNickName, String projectName, String cardName, String nickName) {
+        String key = "notification:" + cardMasterUser;
+        String message = String.format("%s의 %s 카드에 %s님이 댓글을 달았습니다.", projectName, cardName, nickName);
+        if(!Objects.equals(cardMasterNickName, nickName)) {
+            redisTemplate.opsForList().rightPush(key, message);
+            redisTemplate.expire(key, 3, TimeUnit.DAYS);
+        }
+    }
+
+    public List<String> getCommentNotifications(Long cardMasterUser) {
+        String key = "notification:" + cardMasterUser;
+        List<String> userNotifications = redisTemplate.opsForList().range(key, 0, -1);
+        if (userNotifications == null || userNotifications.isEmpty()) {
+            throw new NotificationNotFoundException(ResponseExceptionEnum.NOTIFICATION_NOT_FOUND);
+        }
+        return userNotifications;
+    }
 }

--- a/src/main/java/com/pm/projectmanager/common/response/ResponseCodeEnum.java
+++ b/src/main/java/com/pm/projectmanager/common/response/ResponseCodeEnum.java
@@ -52,7 +52,9 @@ public enum ResponseCodeEnum {
     COMMENT_CREATE_SUCCESS(HttpStatus.OK, "댓글 생성 성공"),
     COMMENT_SELECT_SUCCESS(HttpStatus.OK, "댓글 조회 성공"),
     COMMENT_UPDATE_SUCCESS(HttpStatus.OK, "댓글 수정 성공"),
-    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "댓글 삭제 성공");
+    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "댓글 삭제 성공"),
+    // notification
+    COMMENT_NOTIFICATION_SELECT_SUCCESS(HttpStatus.OK, "댓글 알림 조회 성공");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/pm/projectmanager/common/response/ResponseExceptionEnum.java
+++ b/src/main/java/com/pm/projectmanager/common/response/ResponseExceptionEnum.java
@@ -12,6 +12,7 @@ public enum ResponseExceptionEnum {
 	EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "중복된 이메일입니다."),
 	NICKNAME_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "중복된 닉네임입니다."),
 	PASSWORD_INCORRECT(HttpStatus.BAD_REQUEST, "패스워드가 일치하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "존재하지 않는 유저 입니다."),
 	// project
 	PROJECT_NOT_FOUND(HttpStatus.NOT_FOUND, "프로젝트를 찾을 수 없습니다."),
 	AUTHORITY_NULL_EXCEPTION(HttpStatus.FORBIDDEN, "해당 프로젝트에 권한이 없습니다."),
@@ -29,7 +30,9 @@ public enum ResponseExceptionEnum {
     CARD_ALREADY_COMPLETED(HttpStatus.BAD_REQUEST, "이미 완료 되어있는 카드 입니다."),
     CARD_ALREADY_IN_PROGRESS(HttpStatus.BAD_REQUEST, "이미 진행 되고있는 카드 입니다."),
     // comment
-    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다.");
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글을 찾을 수 없습니다."),
+    // notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "댓글 관련 알림이 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/pm/projectmanager/domain/category/CategoryService.java
+++ b/src/main/java/com/pm/projectmanager/domain/category/CategoryService.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
-import java.sql.SQLIntegrityConstraintViolationException;
 import java.util.List;
 import java.util.Optional;
 

--- a/src/main/java/com/pm/projectmanager/domain/comment/CommentService.java
+++ b/src/main/java/com/pm/projectmanager/domain/comment/CommentService.java
@@ -1,14 +1,18 @@
 package com.pm.projectmanager.domain.comment;
 
+import com.pm.projectmanager.common.RedisService;
 import com.pm.projectmanager.common.response.ResponseExceptionEnum;
 import com.pm.projectmanager.domain.card.Card;
 import com.pm.projectmanager.domain.card.CardRepository;
 import com.pm.projectmanager.domain.comment.dto.CreateCommentRequestDto;
 import com.pm.projectmanager.domain.comment.dto.SelectAllCommentResponseDto;
 import com.pm.projectmanager.domain.comment.dto.UpdateCommentRequestDto;
+import com.pm.projectmanager.domain.project.ProjectService;
 import com.pm.projectmanager.domain.user.User;
+import com.pm.projectmanager.domain.user.UserRepository;
 import com.pm.projectmanager.exception.CardNotFoundException;
 import com.pm.projectmanager.exception.CommentNotFoundException;
+import com.pm.projectmanager.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,6 +25,8 @@ public class CommentService {
 
     private final CommentRepository commentRepository;
     private final CardRepository cardRepository;
+    private final UserRepository userRepository;
+    private final RedisService redisService;
 
     public void createComment(CreateCommentRequestDto requestDto, User user, Long cardId) {
         Card card = cardRepository.findById(cardId).orElseThrow(
@@ -32,6 +38,10 @@ public class CommentService {
                 .user(user).build();
 
         commentRepository.save(comment);
+        User cardMasterUser = userRepository.findById(card.getUser().getId()).orElseThrow(
+                () -> new UserNotFoundException(ResponseExceptionEnum.USER_NOT_FOUND)
+        );
+        redisService.commentNotifications(cardMasterUser.getId(), cardMasterUser.getNickname(), card.getSection().getProject().getName(), card.getTitle(), user.getNickname());
     }
 
     public List<SelectAllCommentResponseDto> selectAllComment(User user, Long cardId) {

--- a/src/main/java/com/pm/projectmanager/domain/notification/NotificationController.java
+++ b/src/main/java/com/pm/projectmanager/domain/notification/NotificationController.java
@@ -1,0 +1,32 @@
+package com.pm.projectmanager.domain.notification;
+
+import com.pm.projectmanager.common.RedisService;
+import com.pm.projectmanager.common.response.HttpResponseDto;
+import com.pm.projectmanager.security.UserDetailsImpl;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+import static com.pm.projectmanager.common.response.ResponseCodeEnum.*;
+import static com.pm.projectmanager.common.response.ResponseUtils.of;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/notification")
+public class NotificationController {
+
+    private final RedisService redisService;
+
+    @GetMapping("/comment")
+    public ResponseEntity<HttpResponseDto> getCommentNotification(
+            @AuthenticationPrincipal UserDetailsImpl userDetails)
+    {
+        List<String> notifications = redisService.getCommentNotifications(userDetails.getUser().getId());
+        return of(COMMENT_NOTIFICATION_SELECT_SUCCESS, notifications);
+    }
+}

--- a/src/main/java/com/pm/projectmanager/exception/NotificationNotFoundException.java
+++ b/src/main/java/com/pm/projectmanager/exception/NotificationNotFoundException.java
@@ -1,0 +1,9 @@
+package com.pm.projectmanager.exception;
+
+import com.pm.projectmanager.common.response.ResponseExceptionEnum;
+
+public class NotificationNotFoundException extends CommonException {
+    public NotificationNotFoundException(ResponseExceptionEnum responseExceptionEnum) {
+        super(responseExceptionEnum);
+    }
+}

--- a/src/main/java/com/pm/projectmanager/exception/UserNotFoundException.java
+++ b/src/main/java/com/pm/projectmanager/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.pm.projectmanager.exception;
+
+import com.pm.projectmanager.common.response.ResponseExceptionEnum;
+
+public class UserNotFoundException extends CommonException {
+    public UserNotFoundException(ResponseExceptionEnum responseExceptionEnum) {
+        super(responseExceptionEnum);
+    }
+}


### PR DESCRIPTION
## 🏠 제목
> [Feature] 댓글 알림 기능 구현

## #️⃣ 관련 이슈
> Closes #47 

## 📑 작업 내용
> - Controller: /api/notifications/comment 엔드포인트 추가.
> -알림 생성은 댓글 생성과 동시에 생성이 되야함. 즉, CommentService 서비스 레이어에 create부분에 추가
> -create 부분에서 redisService 레이어 호출 redisService레이어에선 값을 redis에 삽입
> -알림 조회 -> 따로 추가한 notifications 컨트롤러 만든 후 redis에서 조회

## ✅ 참고 사항
> - 알림 자동 삭제 기한을 3일로 지정함. 추후에 회의를 통해 변경 필요
