### PR TITLE
refactor: 프로젝트 초대 정보 set 대신 list로 refactor

### DIFF
--- a/src/main/java/com/pm/projectmanager/common/RedisService.java
+++ b/src/main/java/com/pm/projectmanager/common/RedisService.java
@@ -31,15 +31,16 @@ public class RedisService {
 	}
 
 	public void invite(String email, Long projectId) {
-		redisTemplate.opsForSet().add(inviteKey(email), String.valueOf(projectId));
+		redisTemplate.opsForList().rightPush(inviteKey(email), String.valueOf(projectId));
 	}
 
 	public boolean checkInvite(String email, Long projectId) {
-		return redisTemplate.opsForSet().isMember(inviteKey(email), String.valueOf(projectId));
+		List<String> invites = redisTemplate.opsForList().range(inviteKey(email), 0, -1);
+		return invites != null && invites.contains(String.valueOf(projectId));
 	}
 
-	public Set<String> getInvites(String email) {
-		return redisTemplate.opsForSet().members(inviteKey(email));
+	public List<String> getInvites(String email) {
+		return redisTemplate.opsForList().range(inviteKey(email), 0, -1);
 	}
 
 	private String inviteKey(String email) {
@@ -51,7 +52,7 @@ public class RedisService {
 	}
 
 	public void deleteInvite(String email, Long projectId) {
-		redisTemplate.opsForSet().remove((inviteKey(email)), String.valueOf(projectId));
+		redisTemplate.opsForList().remove(inviteKey(email), 1, String.valueOf(projectId));
 	}
 
     public void commentNotifications(Long cardMasterUser, String cardMasterNickName, String projectName, String cardName, String nickName) {

--- a/src/main/java/com/pm/projectmanager/domain/notification/NotificationController.java
+++ b/src/main/java/com/pm/projectmanager/domain/notification/NotificationController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+import java.util.Set;
 
 import static com.pm.projectmanager.common.response.ResponseCodeEnum.*;
 import static com.pm.projectmanager.common.response.ResponseUtils.of;
@@ -21,6 +22,7 @@ import static com.pm.projectmanager.common.response.ResponseUtils.of;
 public class NotificationController {
 
     private final RedisService redisService;
+    private final NotificationService notificationService;
 
     @GetMapping("/comment")
     public ResponseEntity<HttpResponseDto> getCommentNotification(
@@ -28,5 +30,13 @@ public class NotificationController {
     {
         List<String> notifications = redisService.getCommentNotifications(userDetails.getUser().getId());
         return of(COMMENT_NOTIFICATION_SELECT_SUCCESS, notifications);
+    }
+
+    @GetMapping("/invites")
+    public ResponseEntity<HttpResponseDto> getInvite(
+        @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        List<String> projectIds = notificationService.getInvites(userDetails);
+        return of(PROJECT_INVITE_GET_SUCCESS, projectIds);
     }
 }

--- a/src/main/java/com/pm/projectmanager/domain/notification/NotificationService.java
+++ b/src/main/java/com/pm/projectmanager/domain/notification/NotificationService.java
@@ -1,0 +1,22 @@
+package com.pm.projectmanager.domain.notification;
+
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.stereotype.Service;
+
+import com.pm.projectmanager.common.RedisService;
+import com.pm.projectmanager.security.UserDetailsImpl;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class NotificationService {
+
+	private final RedisService redisService;
+
+	public List<String> getInvites(UserDetailsImpl userDetails) {
+		return redisService.getInvites(userDetails.getUsername());
+	}
+}

--- a/src/main/java/com/pm/projectmanager/domain/project/ProjectController.java
+++ b/src/main/java/com/pm/projectmanager/domain/project/ProjectController.java
@@ -99,14 +99,6 @@ public class ProjectController {
 		return of(PROJECT_INVITE_SUCCESS);
 	}
 
-	@GetMapping("/invites")
-	public ResponseEntity<HttpResponseDto> getInvite(
-		@AuthenticationPrincipal UserDetailsImpl userDetails
-	) {
-		Set<String> projectIds = projectService.getInvite(userDetails);
-		return of(PROJECT_INVITE_GET_SUCCESS, projectIds);
-	}
-
 	@DeleteMapping("/{projectId}/{userId}")
 	public ResponseEntity<HttpResponseDto> deleteUser(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
+++ b/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
@@ -136,9 +136,6 @@ public class ProjectService {
 		}
 	}
 
-	public Set<String> getInvite(UserDetailsImpl userDetails) {
-		return redisService.getInvites(userDetails.getUsername());
-	}
 
 	@Transactional
 	public void inviteAccept(Long projectId, UserDetailsImpl userDetails) {


### PR DESCRIPTION
## 🏠 제목
> 프로젝트 초대 정보 set 대신 list로 refactor

## #️⃣ 관련 이슈
> #6 

## 📑 작업 내용
> - 순서가 저장되지 않는 set대신 List로 알림 순서를 구현할 수 있도록 하였습니다.
> - NotificationService를 만들어, 분리하였습니다. (API주소도 일부 수정)

## ✅ 참고 사항
>
