### PR TITLE
refactor: 로그인 에러 예외처리 추가

### DIFF
--- a/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
+++ b/src/main/java/com/pm/projectmanager/domain/project/ProjectService.java
@@ -254,7 +254,8 @@ public class ProjectService {
 		if (role != UserRole.ADMIN) {
 			throw new UserRoleException(ResponseExceptionEnum.ADMIN_ROLE_REQUIRED);
 		}
-		User targetUser = userRepository.findByEmail(requestDto.getEmail());
+		User targetUser = userRepository.findByEmail(requestDto.getEmail())
+			.orElseThrow(() -> new UserNotFoundException(ResponseExceptionEnum.USER_NOT_FOUND));
 		Authority authority = authorityRepository.findByProjectIdAndUserId(projectId, targetUser.getId());
 
 		authority.updateRole(requestDto.getRole());

--- a/src/main/java/com/pm/projectmanager/domain/user/UserRepository.java
+++ b/src/main/java/com/pm/projectmanager/domain/user/UserRepository.java
@@ -1,12 +1,13 @@
 package com.pm.projectmanager.domain.user;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
-	User findByEmail(String email);
+	Optional<User> findByEmail(String email);
 
 	boolean existsByEmail(String email);
 

--- a/src/main/java/com/pm/projectmanager/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/pm/projectmanager/security/JwtAuthenticationFilter.java
@@ -78,6 +78,10 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
     @Override
     protected void unsuccessfulAuthentication(HttpServletRequest req, HttpServletResponse res, AuthenticationException failed) throws IOException {
         res.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        res.getWriter().print("{\"error\":\"Unauthorized\", \"message\":\"" + failed.getMessage() + "\"}");
+        res.setCharacterEncoding("UTF-8");
+        res.setContentType("application/json");
+
+        String jsonResponse = new ObjectMapper().writeValueAsString(new LoginResponseDto(failed.getMessage()));
+        res.getWriter().print(jsonResponse);
     }
 }

--- a/src/main/java/com/pm/projectmanager/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/pm/projectmanager/security/UserDetailsServiceImpl.java
@@ -1,5 +1,7 @@
 package com.pm.projectmanager.security;
 
+import static com.pm.projectmanager.common.response.ResponseExceptionEnum.USER_NOT_FOUND;
+
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -7,6 +9,7 @@ import org.springframework.stereotype.Service;
 
 import com.pm.projectmanager.domain.user.User;
 import com.pm.projectmanager.domain.user.UserRepository;
+import com.pm.projectmanager.exception.UserNotFoundException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -18,7 +21,7 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email);
+        User user = userRepository.findByEmail(email).orElseThrow(() -> new UserNotFoundException(USER_NOT_FOUND));
         return new UserDetailsImpl(user);
     }
 }


### PR DESCRIPTION
## 🏠 제목
> 로그인 에러 예외처리 추가

## #️⃣ 관련 이슈
> 

## 📑 작업 내용
> 아이디 틀릴 시 nullpointer예외 발생으로 500, 비밀번호 틀릴 시 401로 다르게 뜨던 문제 해결
> 동일하게 401 처리

## ✅ 참고 사항
> 
