### PR TITLE
권한 변경 알림 삭제, 소셜로그인 수정

### DIFF
--- a/src/main/java/com/pm/projectmanager/common/RedisService.java
+++ b/src/main/java/com/pm/projectmanager/common/RedisService.java
@@ -303,4 +303,11 @@ public class RedisService {
 		}
 
 	}
+
+	public void deleteRoleChangeNotification(User user, RoleChangeResponseDto responseDto) {
+
+		redisTemplate.opsForList().remove("roleNotification:" + user.getId(), 0, responseDto.getRole());
+
+
+	}
 }

--- a/src/main/java/com/pm/projectmanager/common/response/ResponseCodeEnum.java
+++ b/src/main/java/com/pm/projectmanager/common/response/ResponseCodeEnum.java
@@ -61,6 +61,7 @@ public enum ResponseCodeEnum {
     UPDATE_COMMENT_NOTIFICATION_STATUS_CHECK(HttpStatus.OK, "댓글 알림 확인 성공"),
     NOTIFICATION_COUNT_SELECT_SUCCESS(HttpStatus.OK, "알림 갯수 조회 성공"),
 	ROLE_CHANGE_GET_SUCCESS(HttpStatus.OK, "권한 변경 알림 조회 성공"),
+	DELETE_ROLE_CHANGE_NOTIFICATION(HttpStatus.OK, "권한 변경 알림 삭제 성공"),
     DELETE_COMMENT_NOTIFICATION(HttpStatus.OK, "알림 삭제 성공");
 
 	private final HttpStatus httpStatus;

--- a/src/main/java/com/pm/projectmanager/domain/notification/NotificationController.java
+++ b/src/main/java/com/pm/projectmanager/domain/notification/NotificationController.java
@@ -70,4 +70,13 @@ public class NotificationController {
         List<RoleChangeResponseDto> changes = redisService.getRoleChangeNotifications(userDetails.getUser().getId());
         return of(ROLE_CHANGE_GET_SUCCESS, changes);
     }
+
+    @DeleteMapping("/roles")
+    public ResponseEntity<HttpResponseDto> deleteRoleChanges(
+        @AuthenticationPrincipal UserDetailsImpl userDetails,
+        @RequestBody RoleChangeResponseDto responseDto
+    ) {
+        notificationService.deleteRoleChangeNotification(userDetails, responseDto);
+        return of(DELETE_ROLE_CHANGE_NOTIFICATION);
+    }
 }

--- a/src/main/java/com/pm/projectmanager/domain/notification/NotificationService.java
+++ b/src/main/java/com/pm/projectmanager/domain/notification/NotificationService.java
@@ -5,8 +5,10 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import org.springframework.stereotype.Service;
 
 import com.pm.projectmanager.common.RedisService;
+import com.pm.projectmanager.domain.notification.dto.RoleChangeResponseDto;
 import com.pm.projectmanager.domain.project.ProjectService;
 import com.pm.projectmanager.domain.user.UserRepository;
+import com.pm.projectmanager.security.UserDetailsImpl;
 
 import lombok.RequiredArgsConstructor;
 
@@ -63,4 +65,7 @@ public class NotificationService {
 		redisService.increaseNotificationCount(userId);
 	}
 
+	public void deleteRoleChangeNotification(UserDetailsImpl userDetails, RoleChangeResponseDto responseDto) {
+		redisService.deleteRoleChangeNotification(userDetails.getUser(), responseDto);
+	}
 }

--- a/src/main/java/com/pm/projectmanager/domain/user/KakaoService.java
+++ b/src/main/java/com/pm/projectmanager/domain/user/KakaoService.java
@@ -43,12 +43,10 @@ public class KakaoService {
 	private final JwtProvider jwtProvider;
 	private final RedisService redisService;
 	public static final String AUTHORIZATION_HEADER = "Authorization";
-	@Value("${kakao-redirect-uri}")
-	public String redirectUri;
 
-	public KakaoLoginResponseDto kakaoLogin(String code, HttpServletResponse res) throws JsonProcessingException {
+	public KakaoLoginResponseDto kakaoLogin(String code, String uri, HttpServletResponse res) throws JsonProcessingException {
 		// 1. "인가 코드"로 "액세스 토큰" 요청
-		String tokens = getToken(code);
+		String tokens = getToken(code, uri);
 
 		String KakaoAccessToken = tokens.split(" ")[0];
 
@@ -73,7 +71,7 @@ public class KakaoService {
 	}
 
 	// 인가 코드 받는 메서드
-	public String getToken(String code) throws JsonProcessingException {
+	public String getToken(String code, String redirectUri) throws JsonProcessingException {
 		// 요청 URL 만들기
 		URI uri = UriComponentsBuilder
 			.fromUriString("https://kauth.kakao.com")

--- a/src/main/java/com/pm/projectmanager/domain/user/UserController.java
+++ b/src/main/java/com/pm/projectmanager/domain/user/UserController.java
@@ -103,8 +103,12 @@ public class UserController {
 	}
 
 	@GetMapping("/oauth/kakao")
-	public ResponseEntity<HttpResponseDto> kakaoLogin(@RequestParam String code, HttpServletResponse res)
+	public ResponseEntity<HttpResponseDto> kakaoLogin(
+		@RequestParam String code,
+		@RequestParam String uri,
+		HttpServletResponse res
+		)
 		throws JsonProcessingException {
-		return of(LOGIN_SUCCESS, kakaoService.kakaoLogin(code, res));
+		return of(LOGIN_SUCCESS, kakaoService.kakaoLogin(code, uri, res));
 	}
 }


### PR DESCRIPTION
## 🏠 제목
> 권한 변경 알림 삭제, 소셜로그인 수정

## #️⃣ 관련 이슈
> 

## 📑 작업 내용
> 권한 변경 알림을 삭제하는 기능 추가
> 카카오 로그인 RedirectURI 동적으로 처리 가능하도록 변경

## ✅ 참고 사항
> 
